### PR TITLE
Prevent a FOUT

### DIFF
--- a/setup/templates/base_template.tpl
+++ b/setup/templates/base_template.tpl
@@ -7,16 +7,17 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 
-    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
-
     <style type="text/css">
         body {
             background-color: #eee;
-            font-family: 'Open Sans', sans-serif;
+            font-family: sans-serif;
             font-size: 20px;
             line-height: 1.4em;
             padding: 0;
             margin: 0;
+        }
+        body.loaded {
+          font-family: 'Open Sans', sans-serif;
         }
         .container {
             display: block;
@@ -257,6 +258,15 @@
 <div class="disclaimer">
     <p>&copy; 2005-2016 the <a href="http://www.modx.com/" target="_blank">MODX</a> Content Management Framework (CMF) project. All rights reserved. MODX is licensed under the GNU GPL.</p>
 </div>
+
+<script>
+  try {
+    document.addEventListener("DOMContentLoaded", function() { // prevent a Flash Of Unstyled Text (FOUT)
+      document.querySelector('head').innerHTML += "<link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>";
+      document.body.classList.add('loaded');
+    });
+  } catch (e) {}
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
### What does it do ?
- Defers loading of google font
- Prevents a Flash of Unstyled Text by not setting the font-family to
  google fonts until the initial document is loaded

IE 8 won't get the fonts because they don't have `DOMContentLoaded` event.
### Why is it needed ?

So we don't have a blocking request in front of delivering the content to new users.
### Related issue(s)/PR(s)

See modxcms/revolution#12855

> I would not use the Google CDN because it is blocked in China and other regions, maybe just use Arial or another system font.
> &emsp;&mdash;&nbsp;https://github.com/modxcms/revolution/pull/12855#issuecomment-172047810
