### PR TITLE
Adopting Typographic Orphans

### DIFF
--- a/setup/templates/base_resource.tpl
+++ b/setup/templates/base_resource.tpl
@@ -1,16 +1,16 @@
-<p>You have successfully installed MODX Revolution [[++settings_version]]!</p>
-<p>Now that MODX is installed you can login to the manager to create your templates, manage content and install third party extras to add functionality to your website. </p>
+<p>You have successfully installed MODX&nbsp;Revolution [[++settings_version]]!</p>
+<p>Now that MODX is installed you can login to the manager to create your templates, manage content and install third party extras to add functionality to your&nbsp;website. </p>
 
-<h2>New to MODX?</h2>
+<h2>New to&nbsp;MODX?</h2>
 
-<p>Pages on a MODX site are called <a href="https://rtfm.modx.com/revolution/2.x/making-sites-with-modx/structuring-your-site/resources">Resources</a>, and are visible on the left-hand side of the manager in the Resources tab. Resources can be nested under other resources, making it easy to create a tree of resources. There are different types of resources for different use cases.</p>
+<p>Pages on a MODX site are called <a href="https://rtfm.modx.com/revolution/2.x/making-sites-with-modx/structuring-your-site/resources">Resources</a>, and are visible on the left-hand side of the manager in the Resources tab. Resources can be nested under other resources, making it easy to create a tree of resources. There are different types of resources for different use&nbsp;cases.</p>
 
-<p>Building your website is done through a combination of <b>Templates</b>, <b>Template Variables</b>, <b>Chunks</b>, <b>Snippets</b> and <b>Plugins</b>. Collectively these are known as <b>Elements</b>, and can also be found in the left-hand side of the manager, in the Elements tab.</p>
+<p>Building your website is done through a combination of <b>Templates</b>, <b>Template Variables</b>, <b>Chunks</b>, <b>Snippets</b> and <b>Plugins</b>. Collectively these are known as <b>Elements</b>, and can also be found in the left-hand side of the manager, in the Elements&nbsp;tab.</p>
 
-<p><a href="https://rtfm.modx.com/revolution/2.x/making-sites-with-modx/structuring-your-site/templates">Templates</a> contain the outer markup of any page. Each resource can only be assigned to a single template at a time. By adding <a href="https://rtfm.modx.com/revolution/2.x/making-sites-with-modx/customizing-content/template-variables">Template Variables</a> to a template, you can add custom fields for any resource using that particular template. </p>
+<p><a href="https://rtfm.modx.com/revolution/2.x/making-sites-with-modx/structuring-your-site/templates">Templates</a> contain the outer markup of any page. Each resource can only be assigned to a single template at a time. By adding <a href="https://rtfm.modx.com/revolution/2.x/making-sites-with-modx/customizing-content/template-variables">Template Variables</a> to a template, you can add custom fields for any resource using that particular&nbsp;template.</p>
 
-<p>With <a href="https://rtfm.modx.com/revolution/2.x/making-sites-with-modx/structuring-your-site/chunks">Chunks</a> you can share parts of the markup, such as a header, across different templates. <a href="https://rtfm.modx.com/revolution/2.x/making-sites-with-modx/structuring-your-site/using-snippets">Snippets</a> are pieces of PHP that return dynamic content, such as summaries of other resources or the current date. With snippets, you will often use Chunks to mark up the pieces of content it returns, instead of mixing the PHP and HTML.</p>
+<p>With <a href="https://rtfm.modx.com/revolution/2.x/making-sites-with-modx/structuring-your-site/chunks">Chunks</a> you can share parts of the markup, such as a header, across different templates. <a href="https://rtfm.modx.com/revolution/2.x/making-sites-with-modx/structuring-your-site/using-snippets">Snippets</a> are pieces of PHP that return dynamic content, such as summaries of other resources or the current date. With snippets, you will often use Chunks to mark up the pieces of content it returns, instead of mixing the PHP and&nbsp;HTML.</p>
 
 <p>Finally, <a href="https://rtfm.modx.com/revolution/2.x/developing-in-modx/basic-development/plugins">Plugins</a> enable more advanced features by hooking into the extensive events system provided by MODX.</p>
 
-<p>To learn more about MODX, be sure to check out the <a href="https://rtfm.modx.com/revolution/2.x/getting-started">Getting Started</a> section in the official documentation.</p>
+<p>To learn more about MODX, be sure to check out the <a href="https://rtfm.modx.com/revolution/2.x/getting-started">Getting Started</a> section in the official&nbsp;documentation.</p>

--- a/setup/templates/base_template.tpl
+++ b/setup/templates/base_template.tpl
@@ -246,28 +246,28 @@
         [[*content]]
     </section>
     <aside>
-        <a href="[[++manager_url]]" title="Your MODX manager" class="cta-button">Go to the manager</a>
-        <h3>Learn more about MODX</h3>
+        <a href="[[++manager_url]]" title="Your MODX manager" class="cta-button">Go to the&nbsp;manager</a>
+        <h3>Learn more about&nbsp;MODX</h3>
         <ul>
-            <li><a href="https://rtfm.modx.com/revolution/2.x/">Official Documentation</a></li>
-            <li><a href="https://rtfm.modx.com/revolution/2.x/administering-your-site/using-friendly-urls">Using Friendly URLs</a></li>
-            <li><a href="https://rtfm.modx.com/revolution/2.x/developing-in-modx/advanced-development/package-management/">Package Management</a></li>
-            <li><a href="http://modx.com/blog/">Official MODX Blog</a></li>
-            <li><a href="http://www.discovermodx.com/">Discover MODX</a></li>
+            <li><a href="https://rtfm.modx.com/revolution/2.x/">Official&nbsp;Documentation</a></li>
+            <li><a href="https://rtfm.modx.com/revolution/2.x/administering-your-site/using-friendly-urls">Using Friendly&nbsp;URLs</a></li>
+            <li><a href="https://rtfm.modx.com/revolution/2.x/developing-in-modx/advanced-development/package-management/">Package&nbsp;Management</a></li>
+            <li><a href="http://modx.com/blog/">Official MODX&nbsp;Blog</a></li>
+            <li><a href="http://www.discovermodx.com/">Discover&nbsp;MODX</a></li>
             <li><a href="https://modx.today">MODX.today</a></li>
         </ul>
 
         <h3>Get help!</h3>
         <ul>
-            <li><a href="http://forums.modx.com/">Official MODX Forums</a></li>
-            <li><a href="https://modx.org/">MODX Community on Slack</a></li>
-            <li><a href="http://modx.com/professionals/">Find a MODX Professional</a></li>
+            <li><a href="http://forums.modx.com/">Official MODX&nbsp;Forums</a></li>
+            <li><a href="https://modx.org/">MODX Community on&nbsp;Slack</a></li>
+            <li><a href="http://modx.com/professionals/">Find a MODX&nbsp;Professional</a></li>
         </ul>
     </aside>
     <div class="companies">
-        <h3>Extend MODX with Extras</h3>
+        <h3>Extend MODX with&nbsp;Extras</h3>
         <ul>
-            <li class="modxextras"><a href="http://modx.com/extras/" title="MODX extras" target="_blank">MODX extras</a></li>
+            <li class="modxextras"><a href="http://modx.com/extras/" title="MODX extras" target="_blank">MODX&nbsp;extras</a></li>
             <li class="modmore"><a href="https://www.modmore.com/extras/" title="modmore.com" target="_blank">modmore.com</a></li>
             <li class="modstore"><a href="https://modstore.pro/" title="modstore.pro" target="_blank">modstore.pro</a></li>
             <li class="extrasio"><a href="https://extras.io/extras/" title="Extras.io" target="_blank">Extras.io</a></li>
@@ -275,7 +275,7 @@
     </div>
 </div>
 <footer class="disclaimer">
-    <p>&copy; 2005-2016 the <a href="http://www.modx.com/" target="_blank">MODX</a> Content Management Framework (CMF) project. All rights reserved. MODX is licensed under the GNU GPL.</p>
+    <p>&copy; 2005-2016 the <a href="http://www.modx.com/" target="_blank">MODX</a> Content Management Framework (CMF) project. All rights reserved. MODX is licensed under the GNU&nbsp;GPL.</p>
 </footer>
 
 <script>


### PR DESCRIPTION
### What does it do?

Used `&nbsp;` HTML Entity to prevent typographic orphans.
### Why is it needed?

To enhance the typography of the page. 
### Related issue(s)/PR(s)

n/a
